### PR TITLE
Add per-app GPU usage

### DIFF
--- a/src/Website/JS/applications_charts.js
+++ b/src/Website/JS/applications_charts.js
@@ -41,6 +41,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 </td>
                 <td>${app.pid}</td>
                 <td>${app.cpu_percent.toFixed(2)}</td>
+                <td>${app.gpu_percent}</td>
                 <td>${(app.memory_info.rss / (1024 * 1024)).toFixed(0)}</td>
                 <td>${(app.read_bytes / (1024 * 1024)).toFixed(0)}</td>
                 <td>${(app.write_bytes / (1024 * 1024)).toFixed(0)}</td>

--- a/src/Website/applications.html
+++ b/src/Website/applications.html
@@ -24,6 +24,7 @@
                     <th class="processname" data-sort="name">Name</th>
                     <th data-sort="pid">PID</th>
                     <th data-sort="cpu_percent">CPU Usage (%)</th>
+                    <th data-sort="gpu_percent">GPU Usage (%)</th>
                     <th data-sort="memory_info">Memory Usage (MB)</th>
                     <th data-sort="read_bytes">Disk Read (MB)</th>
                     <th data-sort="write_bytes">Disk Write (MB)</th>

--- a/src/dashball.go
+++ b/src/dashball.go
@@ -9,8 +9,9 @@ import (
     "net/http"
     "os"   
     "path/filepath"
-    "runtime"    
+    "runtime"
     "strings"
+    "strconv"
     "sync"
     "time"
 
@@ -317,6 +318,7 @@ func fetchSystemInfo() (map[string]interface{}, error) {
 
     hostInfo, _ := host.Info()
     gpuInfo, _ := getNvidiaGPUInfo()
+    gpuProcessUsage := getProcessGPUUsage()
     uptime, _ := host.Uptime()
     uptimeStr := formatUptime(uptime)
     threadCount := runtime.NumGoroutine()
@@ -352,6 +354,10 @@ func fetchSystemInfo() (map[string]interface{}, error) {
         }
 
         pid := p.Pid
+        gpuPercent := 0
+        if val, ok := gpuProcessUsage[int(pid)]; ok {
+            gpuPercent = val
+        }
 
         if app, exists := processMap[name]; exists {
             count := app["process_count"].(int) + 1
@@ -359,11 +365,13 @@ func fetchSystemInfo() (map[string]interface{}, error) {
             app["memory_info"].(*process.MemoryInfoStat).RSS += memInfo.RSS
             app["read_bytes"] = app["read_bytes"].(uint64) + ioCounters.ReadBytes
             app["write_bytes"] = app["write_bytes"].(uint64) + ioCounters.WriteBytes
+            app["gpu_percent"] = (app["gpu_percent"].(int)*(count-1) + gpuPercent) / count
         } else {
             processMap[name] = map[string]interface{}{
                 "name":        name,
                 "exe":         exe,
                 "cpu_percent": cpuPercent,
+                "gpu_percent": gpuPercent,
                 "memory_info": memInfo,
                 "read_bytes":  ioCounters.ReadBytes,
                 "write_bytes": ioCounters.WriteBytes,
@@ -519,6 +527,34 @@ func parseNvidiaSmiOutput(output []byte, err error) (map[string]interface{}, err
         }
     }
     return gpuInfo, nil
+}
+
+func parseNvidiaSmiPmonOutput(output []byte, err error) map[int]int {
+    if err != nil {
+        return map[int]int{}
+    }
+    usage := make(map[int]int)
+    lines := strings.Split(string(output), "\n")
+    for _, line := range lines {
+        line = strings.TrimSpace(line)
+        if line == "" || strings.HasPrefix(line, "#") {
+            continue
+        }
+        fields := strings.Fields(line)
+        if len(fields) < 5 {
+            continue
+        }
+        pid, err := strconv.Atoi(fields[1])
+        if err != nil {
+            continue
+        }
+        sm, err := strconv.Atoi(fields[3])
+        if err != nil {
+            continue
+        }
+        usage[pid] = sm
+    }
+    return usage
 }
 
 func loadComputersConfig() (ComputersConfig, error) {

--- a/src/dashball_linux.go
+++ b/src/dashball_linux.go
@@ -13,3 +13,9 @@ func getNvidiaGPUInfo() (map[string]interface{}, error) {
     output, err := cmd.Output()
     return parseNvidiaSmiOutput(output, err)
 }
+
+func getProcessGPUUsage() map[int]int {
+    cmd := exec.Command("nvidia-smi", "pmon", "-c", "1")
+    output, err := cmd.Output()
+    return parseNvidiaSmiPmonOutput(output, err)
+}

--- a/src/dashball_windows.go
+++ b/src/dashball_windows.go
@@ -15,3 +15,10 @@ func getNvidiaGPUInfo() (map[string]interface{}, error) {
     output, err := cmd.Output()
     return parseNvidiaSmiOutput(output, err)
 }
+
+func getProcessGPUUsage() map[int]int {
+    cmd := exec.Command("nvidia-smi", "pmon", "-c", "1")
+    cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+    output, err := cmd.Output()
+    return parseNvidiaSmiPmonOutput(output, err)
+}


### PR DESCRIPTION
## Summary
- display GPU usage per running application
- parse GPU process usage from `nvidia-smi pmon`
- expose GPU usage data through system info endpoint

## Testing
- `go build -o /tmp/dashball_test ./src`

------
https://chatgpt.com/codex/tasks/task_e_6842bb943760832aab299b1b2b9153f5